### PR TITLE
adding an OK (not perfect) option for squash and merges for linting shell script

### DIFF
--- a/.github/scripts/modified_files.sh
+++ b/.github/scripts/modified_files.sh
@@ -1,3 +1,3 @@
 # echos modified python files, but excludes those deleted
-changed_files=$(git diff --diff-filter=d --name-only $(git merge-base HEAD remotes/origin/main) HEAD | grep .py)
+changed_files=$(git diff --diff-filter=d --name-only $(git merge-base HEAD remotes/origin/main) HEAD${for_merge_trigger} | grep .py)
 echo ${changed_files}

--- a/.github/workflows/full_workflow.yaml
+++ b/.github/workflows/full_workflow.yaml
@@ -30,6 +30,9 @@ jobs:
       - run: echo "event name is:" ${{ github.event_name }} 
       - run: echo "event type is:" ${{ github.event.action }} 
 
+      - run: for_merge_trigger='~1'
+        if: ${{ github.event_name == 'push'}} 
+
       - name: install black formatter
         run: pip install black
 
@@ -37,7 +40,7 @@ jobs:
         id: get_modified_files
         run: echo MODIFIED_FILES=$(./.github/scripts/modified_files.sh) >> $GITHUB_ENV
       
-      - name: return modified files
+      - name: return modified python files
         run: echo $(./.github/scripts/modified_files.sh)
 
       - name: github script (before replace token)
@@ -60,7 +63,7 @@ jobs:
       - name: List branches
         run: git branch -a
 
-      - name: Lint modified files with Black
+      - name: Lint modified Python files with Black
         run: |
           if [ -z "$MODIFIED_FILES" ]; then
             echo "No Python files modified."


### PR DESCRIPTION
will have to come up with a better method, as this will not work as desired when PR is open and dev pushes to branch under review.

May have to abandon squash-and-merge strategy in future